### PR TITLE
feat(signup): implementa a página de 'signup'

### DIFF
--- a/po-sample-app-conference/src/app/app-routing.module.ts
+++ b/po-sample-app-conference/src/app/app-routing.module.ts
@@ -30,13 +30,17 @@ const routes: Routes = [
         loadChildren: () => import('./login/login.module').then(m => m.LoginModule),
       },
       {
+        path: 'signup',
+        loadChildren: () => import('./signup/signup.module').then(m => m.SignupModule)
+      },
+      {
         path: 'speakers',
         loadChildren: () => import('./speaker-list/speaker-list.module').then(m => m.SpeakerListModule),
       },
       {
         path: 'speaker-detail/:speakerId',
         loadChildren: () => import('./speaker-detail/speaker-detail.module').then(m => m.SpeakerDetailModule),
-      },
+      }
     ]
   },
   // {
@@ -44,10 +48,6 @@ const routes: Routes = [
   //   loadChildren: () => import('./tabs/tabs.module').then(m => m.TabsModule),
   // },
   // {
-  // {
-  //   path: 'signup',
-  //   loadChildren: () => import('./pages/signup/signup.module').then(m => m.SignUpModule)
-  // },
   // {
   //   path: 'app',
   //   loadChildren: () => import('./pages/tabs-page/tabs-page.module').then(m => m.TabsModule)

--- a/po-sample-app-conference/src/app/app.component.ts
+++ b/po-sample-app-conference/src/app/app.component.ts
@@ -41,11 +41,11 @@ export class AppComponent implements OnInit {
       url: '/login',
       icon: 'log-in'
     },
-    // {
-    //   title: 'Signup',
-    //   url: '/signup',
-    //   icon: 'person-add'
-    // }
+    {
+      title: 'Signup',
+      url: '/signup',
+      icon: 'person-add'
+    }
   ];
 
   loggedIn: boolean;

--- a/po-sample-app-conference/src/app/login/login.component.html
+++ b/po-sample-app-conference/src/app/login/login.component.html
@@ -11,6 +11,8 @@
 <ion-content>
 
   <po-page-login
+    p-product-name="Conference"
+    p-logo="https://po-ui.io/assets/po-logos/po_color.svg"
     (p-login-submit)="onLogin($event)"
     p-hide-remember-user>
   </po-page-login>

--- a/po-sample-app-conference/src/app/login/login.component.ts
+++ b/po-sample-app-conference/src/app/login/login.component.ts
@@ -29,10 +29,6 @@ export class LoginComponent {
       .catch(() => this.createToast());
   }
 
-  onSignup() {
-    this.router.navigateByUrl('/schedule');
-  }
-
   private async createToast() {
     const toast = await this.toastCtrl.create({
       message: 'User or password are incorrect',

--- a/po-sample-app-conference/src/app/schedule/schedule-favorite-list/schedule-favorite-list.component.ts
+++ b/po-sample-app-conference/src/app/schedule/schedule-favorite-list/schedule-favorite-list.component.ts
@@ -34,7 +34,7 @@ export class ScheduleFavoriteListComponent {
   }
 
   addLisToFavor(lectureId) {
-    const indexLecture = this.lecturesListToFavor.indexOf(lectureId);
+    const indexLecture = this.lecturesListToFavor?.indexOf(lectureId);
 
     if (indexLecture < 0) {
       this.lecturesListToFavor.push(lectureId);
@@ -44,7 +44,7 @@ export class ScheduleFavoriteListComponent {
   }
 
   checkFavoriteAll() {
-    return !this.lectures.some(lecture => this.favorites.indexOf(lecture.id) < 0);
+    return !this.lectures.some(lecture => this.favorites?.indexOf(lecture.id) < 0);
   }
 
   favoriteLectures() {

--- a/po-sample-app-conference/src/app/services/user.service.ts
+++ b/po-sample-app-conference/src/app/services/user.service.ts
@@ -100,7 +100,7 @@ export class UserService {
     return this.poSync.sync();
   }
 
-  private logIn(foundUser) {
+  logIn(foundUser) {
     return this.poStorage.set('login', { userId: foundUser.id });
   }
 

--- a/po-sample-app-conference/src/app/signup/signup.component.html
+++ b/po-sample-app-conference/src/app/signup/signup.component.html
@@ -1,15 +1,18 @@
 <ion-header>
-  <ion-navbar color="primary">
-    <button ion-button menuToggle>
-      <ion-icon name="menu"></ion-icon>
-    </button>
-    <ion-title>Signup</ion-title>
-  </ion-navbar>
+
+  <ion-toolbar color="primary">
+    <ion-buttons slot="start">
+      <ion-menu-button></ion-menu-button>
+    </ion-buttons>
+    <ion-title class="ion-margin-start">Signup</ion-title>
+  </ion-toolbar>
 </ion-header>
 
-<ion-content class="login-page">
+<ion-content>
 
   <po-page-login
+    p-logo="https://po-ui.io/assets/po-logos/po_color.svg"
+    p-product-name="Conference"
     [p-literals]="customLiterals"
     p-hide-remember-user
     (p-login-submit)="onSignup($event)">

--- a/po-sample-app-conference/src/app/signup/signup.component.ts
+++ b/po-sample-app-conference/src/app/signup/signup.component.ts
@@ -1,12 +1,12 @@
 import { Component } from '@angular/core';
-
-import { NavController } from '@ionic/angular';
+import { Router } from '@angular/router';
 
 import { PoPageLogin, PoPageLoginLiterals } from '@po-ui/ng-templates';
 import { PoStorageService } from '@po-ui/ng-storage';
 import { PoSyncService } from '@po-ui/ng-sync';
 
 import { UserService } from './../services/user.service';
+import { Events } from './../services/events.service';
 
 @Component({
   selector: 'page-user',
@@ -21,10 +21,11 @@ export class SignupComponent {
   customRequestId;
 
   constructor(
-    public navCtrl: NavController,
+    private events: Events,
     private poStorage: PoStorageService,
     private poSync: PoSyncService,
-    private userService: UserService) {
+    private userService: UserService,
+    private router: Router) {
     this.httpCommandEvents();
   }
 
@@ -33,22 +34,25 @@ export class SignupComponent {
     this.customRequestId = newUser.username;
 
     this.userService.createUser(newUser);
-    // this.navCtrl.push(TabsPage);
   }
 
   private httpCommandEvents() {
-    // this.poSync.getResponses().subscribe(poSyncResponse => {
+    this.poSync.getResponses().subscribe(poSyncResponse => {
 
-    //   if (poSyncResponse.customRequestId === this.customRequestId) {
-    //     const userId = poSyncResponse.response['body'].id;
+      if (poSyncResponse.customRequestId === this.customRequestId) {
+        const key = 'body';
+        const user = poSyncResponse.response[key];
 
-    //     this.poStorage.set('login', { userId }).then(() => {
-    //       this.events.publish('user:login');
-    //       this.navCtrl.push(TabsPage);
-    //     });
+        this.poSync.onSync().subscribe(() => this.logIn(user));
+      }
+    });
+  }
 
-    //   }
-    // });
+  private logIn(user: any) {
+    this.userService.logIn(user).then(() => {
+      this.events.publish('user:login');
+      this.router.navigateByUrl('/schedule');
+    });
   }
 
 }

--- a/po-sample-app-conference/src/app/signup/signup.module.ts
+++ b/po-sample-app-conference/src/app/signup/signup.module.ts
@@ -3,6 +3,8 @@ import { CommonModule } from '@angular/common';
 
 import { IonicModule } from '@ionic/angular';
 
+import { PoTemplatesModule } from '@po-ui/ng-templates';
+
 import { SignupComponent } from './signup.component';
 import { SignupComponentRoutingModule } from './signup.routing';
 
@@ -11,6 +13,7 @@ import { SignupComponentRoutingModule } from './signup.routing';
     CommonModule,
     IonicModule,
     SignupComponentRoutingModule,
+    PoTemplatesModule
   ],
   declarations: [SignupComponent]
 })


### PR DESCRIPTION
Definida a página de signup

**Simulação:**
**Subir a API:**
no repositório do projeto thf-conference-api (github - https://github.com/totvs/thf-conference-sample), dentro da pasta thf-conference-api, alterar o arquivo writer.js na linha 39: alterar de 'totvs_sync_date' para 'po-sync-date' e rodar o nodemon index.js ou npm run start.

**APP:**
git checkout sample-app/DTHFUI-3364
npm install
ionic serve

**Teste:** 
Comparar a funcionalidade com a funcionalidade existente no repositório antigo (onde está a api)